### PR TITLE
♻️ Change disposable rule to check for subscribeOn, etc.

### DIFF
--- a/affirm-custom-ruleset/src/main/kotlin/com/affirm/central/ruleset/DisposableNotSaved.kt
+++ b/affirm-custom-ruleset/src/main/kotlin/com/affirm/central/ruleset/DisposableNotSaved.kt
@@ -31,7 +31,7 @@ class DisposableNotSaved : Rule() {
                 .any {
                     line ->
                     disposableNames.any {
-                        line.contains(it) && (line.contains(".add") || line.contains("="))
+                        line.contains("$it = ") || line.contains("$it.add")
                     }
                 }
 

--- a/affirm-custom-ruleset/src/test/kotlin/com/affirm/central/ruleset/DisposabbleNotSavedSpec.kt
+++ b/affirm-custom-ruleset/src/test/kotlin/com/affirm/central/ruleset/DisposabbleNotSavedSpec.kt
@@ -22,12 +22,6 @@ class DisposabbleNotSavedSpec : SubjectSpek<DisposableNotSaved>({
             Assertions.assertThat(subject.findings).hasSize(0)
         }
 
-        it("should ignore classes that don't use protocolGateway") {
-            val ktFile = compileContentForTest(notSubscribingCode)
-            subject.visit(ktFile)
-            Assertions.assertThat(subject.findings).hasSize(0)
-        }
-
         it("should ignore classes that aren't presenters") {
             val ktFile = compileContentForTest(notPresenter)
             subject.visit(ktFile)
@@ -68,23 +62,6 @@ private val perfectCode: String = {
                     .subscribe()
                     .let { disposables.add(it) }
 			    }
-			}
-		"""
-}.invoke()
-
-private val notSubscribingCode: String = {
-    """
-			package one.ui.view
-			class MissingOnDetachView : LinearLayout() {
-
-				override fun onAttachedToWindow() {
-					presenter.onAttach(this)
-                    protocolGateway.callStuff()
-				}
-
-				override fun onDetachedFromWindow() {
-					presenter.onDetach()
-				}
 			}
 		"""
 }.invoke()


### PR DESCRIPTION
- save all names of Disposable
- if a function has "subscribeOn", "observeOn" and "subscribe(", loop through the disposables and see if any of them was used to save the call